### PR TITLE
Revised ACF

### DIFF
--- a/cap_util/__init__.py
+++ b/cap_util/__init__.py
@@ -336,22 +336,28 @@ def get_websocket_address():
 def calc_compression_factor(width, height):
 	# Don't update the element when it can't find a value
 	final_compression_factor = None
+	# Initialize with a very large number
+	smallest_gap = float('inf')
 	# Start from the highest compression factor as lower factors have better quality
-	for compression in range(80, 31, -1):
+	for compression in range(80, 15, -1):
 		res_se = min(width, height)
 		res_le = max(width, height)
 		aspect = res_le / res_se
-		
+
 		latent_min = res_se // compression
 		latent_max = res_le // compression
 		latent_div = (latent_max + latent_min) / 2
-		
-		new_center = remap(aspect, 1, 3.75, 32, 40)
-		new_center = clamp(new_center, 31.5, 40)
-		
-		if latent_div >= new_center-1 and latent_div <= new_center:
+
+		new_center = remap(aspect, 1, 3.75, 32, 38.5)
+		new_center = clamp(new_center, 32, 38.5)
+
+		# Calculate the absolute difference between latent_div and new_center
+		gap = abs(latent_div - new_center)
+
+		# Update the smallest_gap and final_compression_factor accordingly
+		if gap < smallest_gap:
+			smallest_gap = gap
 			final_compression_factor = compression
-			break
 
 	return final_compression_factor
 

--- a/cap_util/gui_generics.py
+++ b/cap_util/gui_generics.py
@@ -171,7 +171,7 @@ def get_generation_settings_column(global_ctx, local_ctx):
 				)
 
 				local_ctx["stage_c_compression"] = gr.Slider(
-					minimum=32,
+					minimum=16,
 					maximum=80,
 					info="The recommended default compression factor is 42. Automatic Compression Finder will find the compression factor that results in the best quality for your resolution. When compression reaches 80, higher resolutions can become unstable.",
 					value=cap_util.gui_default_settings["gen_compression"],


### PR DESCRIPTION
Key changes
- change remap/clamp of 1-3.75 aspects to 32-38.5 latent means to match https://gist.github.com/Jordach/b682f60dc066f343b99d1795cdb3f5d5's minimum and maximum aspects/latent means.
- change range of 1 match of latent_div and new_center to instead seek out the smallest gap between both values, this prevents undershoots/overshoots where the compression is off by 1 what should actually be ideal. no need to break the loop on the first match as it will continue iterating to find the smallest gap between latent_div and new_center and naturally stop there.
- change minimum compression factor from 32 to 16 to cover rare edge cases where width/height is under 1024 with tall/wide aspects.